### PR TITLE
feat(taskdef): allow to use external ECS task def

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ module "ecr" {
 }
 ```
 
+### Use an external ECS Task definition
+
+```hcl
+module "ecr" {
+  source  = "tbobm/ecs/aws"
+  # version = "" use latest version
+
+  ecs_values = {
+    ecs_task_arn = "arn:aws:ecs:<region>:<aws_account_id>:task-definition/<task_family>:1"
+  }
+  networking = {
+    vpc_id = "vpc-xxxxxxxx"
+    subnet_ids = ["subnet-xxxxxxxx"]
+  }
+}
+```
+
 ## Doc generation
 
 Code formatting and documentation for variables and outputs is generated using

--- a/ecs.tf
+++ b/ecs.tf
@@ -9,6 +9,8 @@ resource "aws_ecs_cluster" "this" {
 }
 
 resource "aws_ecs_task_definition" "this" {
+  count = lookup(local.ecs, "ecs_task_arn", "") != "" ? 0 : 1
+
   family = "service"
   requires_compatibilities = [
     "FARGATE",
@@ -36,7 +38,7 @@ resource "aws_ecs_task_definition" "this" {
 resource "aws_ecs_service" "this" {
   name            = local.ecs.service_name
   cluster         = aws_ecs_cluster.this.id
-  task_definition = aws_ecs_task_definition.this.arn
+  task_definition = lookup(local.ecs, "ecs_task_arn", "") != "" ? local.ecs.ecs_task_arn : aws_ecs_task_definition.this.0.arn
   desired_count   = 1
 
   network_configuration {

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -10,6 +10,10 @@ module "ecs" {
     subnet_ids = data.aws_subnet_ids.this.ids
   }
 
+  ecs_values = {
+    ecs_task_arn = ""
+  }
+
   addons = {
     loadbalancer = {
       enable = true

--- a/locals.tf
+++ b/locals.tf
@@ -8,6 +8,7 @@ locals {
   ecs_defaults = {
     cluster_name = "ecs-cluster"
     service_name = "ecs-service"
+    ecs_task_arn = null
   }
   ecs = merge(local.ecs_defaults, var.ecs_values)
 


### PR DESCRIPTION
Reference the target Task definition using `ecs_values.ecs_task_arn`.

Closes #10
